### PR TITLE
Announce the logout via a custom event

### DIFF
--- a/action.php
+++ b/action.php
@@ -50,11 +50,15 @@ class action_plugin_autologoff extends DokuWiki_Action_Plugin {
 
         // check if the time has expired meanwhile
         if(isset($_SESSION[DOKU_COOKIE]['autologoff'])) {
-            if(time() - $_SESSION[DOKU_COOKIE]['autologoff'] > $time * 60) {
+            /** @var int $idle_time */
+            $idle_time = time() - $_SESSION[DOKU_COOKIE]['autologoff'];
+            if( $idle_time > $time * 60) {
                 msg(sprintf($this->getLang('loggedoff'), hsc($_SERVER['REMOTE_USER'])));
-
                 unset($_SESSION[DOKU_COOKIE]['autologoff']);
+                $event = new Doku_Event('ACTION_AUTH_AUTOLOGOUT', $idle_time);
+                $event->advise_before(false);
                 auth_logoff();
+                $event->advise_after();
                 send_redirect(wl($ID, '', true, '&'));
             }
         }

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,8 @@
 base   autologoff
 author Andreas Gohr
 email  dokuwiki@cosmocode.de
-date   2015-02-26
+date   2015-03-10
 name   autologoff plugin
 desc   Automatically log out users after a defined period of inactivity
 url    http://www.dokuwiki.org/plugin:autologoff
+-


### PR DESCRIPTION
The event ``ACTION_AUTH_AUTOLOGOUT`` can be used by other plugins like https://www.dokuwiki.org/plugin:loglog to perform actions almost like during a normal logout. However the event is uninteruptable so the logout process cannot be stopped.