### PR TITLE
PHP Strict and security practice

### DIFF
--- a/action.php
+++ b/action.php
@@ -23,7 +23,7 @@ class action_plugin_autologoff extends DokuWiki_Action_Plugin {
      * @param Doku_Event_Handler $controller DokuWiki's event controller object
      * @return void
      */
-    public function register(Doku_Event_Handler &$controller) {
+    public function register(Doku_Event_Handler $controller) {
 
         $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'handle_dokuwiki_started');
         $controller->register_hook('DETAIL_STARTED', 'BEFORE', $this, 'handle_dokuwiki_started');

--- a/admin.php
+++ b/admin.php
@@ -36,11 +36,11 @@ class admin_plugin_autologoff extends DokuWiki_Admin_Plugin {
      * Should carry out any processing required by the plugin.
      */
     public function handle() {
-        if(isset($_REQUEST['remove'])){
+        if(isset($_REQUEST['remove']) && checkSecurityToken()){
             $this->helper->remove_entry($_REQUEST['remove']);
         }
 
-        if(isset($_REQUEST['usergroup'])){
+        if(isset($_REQUEST['usergroup']) && checkSecurityToken()){
             $this->helper->add_entry($_REQUEST['usergroup'], $_REQUEST['time']);
         }
 
@@ -58,6 +58,7 @@ class admin_plugin_autologoff extends DokuWiki_Admin_Plugin {
         echo '<form action="'.script().'" method="post">';
         echo '<input type="hidden" name="do" value="admin" />';
         echo '<input type="hidden" name="page" value="autologoff" />';
+        echo '<input type="hidden" name="sectok" value="'.getSecurityToken().'" />';
 
         echo '<table class="inline">';
         echo '<tr>';


### PR DESCRIPTION
This request consists two issue. First one is to prevent PHP Strict error.
The second one is adding `checkSecurityToken()` according to the 
[Security Guidelines](https://www.dokuwiki.org/devel:security#cross_site_request_forgery_csrf)  for Plugin Authors.