### PR TITLE
Remove warning in log

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -68,7 +68,7 @@ class helper_plugin_autologoff extends DokuWiki_Plugin {
     public function usertime() {
         global $INFO;
         global $auth;
-        if(!$_SERVER['REMOTE_USER']) return 0;
+        if(!isset($_SERVER['REMOTE_USER'])) return 0;
 
         // make sure we have group info on the current user
         if(isset($INFO) && isset($INFO['userinfo'])){


### PR DESCRIPTION
Upgrade to isset to check if REMOTE_USER exists in $_SERVER.

```
E_WARNING: Undefined array key "REMOTE_USER"
/dokuwiki/lib/plugins/autologoff/helper.php(71)
```